### PR TITLE
npm audit fix and update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -220,9 +220,9 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
-			"integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
+			"integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -232,9 +232,9 @@
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
 				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.3.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^6.0.0",
+				"eslint-utils": "^1.4.2",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.1",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
@@ -402,9 +402,9 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-			"integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^1.0.0"
@@ -417,14 +417,28 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
-			"integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.7",
-				"acorn-jsx": "^5.0.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"acorn": "^7.0.0",
+				"acorn-jsx": "^5.0.2",
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+					"integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+					"dev": true
+				},
+				"acorn-jsx": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+					"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"wdio-mediawiki": "^0.3.0"
 	},
 	"devDependencies": {
-		"eslint": "^6.1.0",
+		"eslint": "^6.2.2",
 		"eslint-config-wikimedia": "^0.13.1"
 	}
 }


### PR DESCRIPTION
Gets rid of the critical vulnerability by updating eslint-utils.