### PR TITLE
Provide function to select a suggested property

### DIFF
--- a/pageobjects/item.page.js
+++ b/pageobjects/item.page.js
@@ -92,9 +92,9 @@ class ItemPage extends PageMixture {
 		return reference.$( this.constructor.ITEM_WIDGET_SELECTORES.PROPERTY_INPUT );
 	}
 
-	selectSuggestedProperty( propertyId ) {
+	selectSuggestedEntity( entityId ) {
 		const suggestionLabelSelector = this.constructor.GENERAL_SELECTORS.ENTITY_SUGGESTOR_SUGGESTION_LABEL;
-		const suggestionSelector = `${suggestionLabelSelector}[text() = "${propertyId}"]`;
+		const suggestionSelector = `${suggestionLabelSelector}[text() = "${entityId}"]`;
 
 		$( suggestionSelector ).waitForVisible();
 		$( suggestionSelector ).click();

--- a/pageobjects/item.page.js
+++ b/pageobjects/item.page.js
@@ -26,14 +26,6 @@ class ItemPage extends PageMixture {
 		};
 	}
 
-	static get GENERAL_SELECTORS() {
-		const visibleCondition = 'not(contains(@style,"display: none"))';
-
-		return {
-			VISIBLE_ENTITY_SUGGESTION: `//ul[contains(@class, "ui-suggester-list")][${visibleCondition}]//li`
-		};
-	}
-
 	open( entityId ) {
 		super.openTitle( `Special:EntityPage/${entityId}` );
 	}
@@ -90,11 +82,6 @@ class ItemPage extends PageMixture {
 	getNthReferencePropertyInput( statement, referenceIndex ) {
 		const reference = statement.$$( this.constructor.ITEM_WIDGET_SELECTORES.REFERENCES )[ referenceIndex ];
 		return reference.$( this.constructor.ITEM_WIDGET_SELECTORES.PROPERTY_INPUT );
-	}
-
-	selectFirstSuggestedEntity() {
-		$( this.constructor.GENERAL_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).waitForVisible();
-		$( this.constructor.GENERAL_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).click();
 	}
 
 	editItemDescription( description ) {

--- a/pageobjects/item.page.js
+++ b/pageobjects/item.page.js
@@ -27,10 +27,10 @@ class ItemPage extends PageMixture {
 	}
 
 	static get GENERAL_SELECTORS() {
-		const xpathVisibleCondition = 'not(contains(@style,"display: none"))';
+		const visibleCondition = 'not(contains(@style,"display: none"))';
 
 		return {
-			ENTITY_SUGGESTOR_SUGGESTION_LABEL: `//ul[${xpathVisibleCondition}]//span[@class="ui-entityselector-label"]`
+			VISIBLE_ENTITY_SUGGESTION: `//ul[contains(@class, "ui-suggester-list")][${visibleCondition}]//li`
 		};
 	}
 
@@ -92,12 +92,9 @@ class ItemPage extends PageMixture {
 		return reference.$( this.constructor.ITEM_WIDGET_SELECTORES.PROPERTY_INPUT );
 	}
 
-	selectSuggestedEntity( entityId ) {
-		const suggestionLabelSelector = this.constructor.GENERAL_SELECTORS.ENTITY_SUGGESTOR_SUGGESTION_LABEL;
-		const suggestionSelector = `${suggestionLabelSelector}[text() = "${entityId}"]`;
-
-		$( suggestionSelector ).waitForVisible();
-		$( suggestionSelector ).click();
+	selectFirstSuggestedEntity() {
+		$( this.constructor.GENERAL_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).waitForVisible();
+		$( this.constructor.GENERAL_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).click();
 	}
 
 	editItemDescription( description ) {

--- a/pageobjects/item.page.js
+++ b/pageobjects/item.page.js
@@ -26,6 +26,14 @@ class ItemPage extends PageMixture {
 		};
 	}
 
+	static get GENERAL_SELECTORS() {
+		const xpathVisibleCondition = 'not(contains(@style,"display: none"))';
+
+		return {
+			ENTITY_SUGGESTOR_SUGGESTION_LABEL: `//ul[${xpathVisibleCondition}]//span[@class="ui-entityselector-label"]`
+		};
+	}
+
 	open( entityId ) {
 		super.openTitle( `Special:EntityPage/${entityId}` );
 	}
@@ -82,6 +90,14 @@ class ItemPage extends PageMixture {
 	getNthReferencePropertyInput( statement, referenceIndex ) {
 		const reference = statement.$$( this.constructor.ITEM_WIDGET_SELECTORES.REFERENCES )[ referenceIndex ];
 		return reference.$( this.constructor.ITEM_WIDGET_SELECTORES.PROPERTY_INPUT );
+	}
+
+	selectSuggestedProperty( propertyId ) {
+		const suggestionLabelSelector = this.constructor.GENERAL_SELECTORS.ENTITY_SUGGESTOR_SUGGESTION_LABEL;
+		const suggestionSelector = `${suggestionLabelSelector}[text() = "${propertyId}"]`;
+
+		$( suggestionSelector ).waitForVisible();
+		$( suggestionSelector ).click();
 	}
 
 	editItemDescription( description ) {

--- a/pagesections/ComponentInteraction.js
+++ b/pagesections/ComponentInteraction.js
@@ -3,12 +3,15 @@
 const ComponentInteraction = ( Base ) => class extends Base {
 
 	static get OOUI_SELECTORS() {
+		const visibleCondition = 'not(contains(@style,"display: none"))';
+
 		return {
 			LOOKUP_OPTION_WIDGET: '.oo-ui-lookupElement-menu .oo-ui-optionWidget',
 			MULTI_OPTION_WIDGET: '.oo-ui-optionWidget',
 			OPTION_WIDGET_SELECTED: '.oo-ui-optionWidget-selected',
 			OVERLAY: '.oo-ui-defaultOverlay',
-			COMBOBOX_DROPDOWN: '.oo-ui-comboBoxInputWidget-dropdownButton'
+			COMBOBOX_DROPDOWN: '.oo-ui-comboBoxInputWidget-dropdownButton',
+			VISIBLE_ENTITY_SUGGESTION: `//ul[contains(@class, "ui-suggester-list")][${visibleCondition}]//li`
 		};
 	}
 
@@ -33,6 +36,11 @@ const ComponentInteraction = ( Base ) => class extends Base {
 		} );
 		// close suggestion overlay
 		element.$( this.constructor.OOUI_SELECTORS.COMBOBOX_DROPDOWN ).click();
+	}
+
+	selectFirstSuggestedEntityOnEntitySelector() {
+		$( this.constructor.GENERAL_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).waitForVisible();
+		$( this.constructor.GENERAL_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).click();
 	}
 };
 

--- a/pagesections/ComponentInteraction.js
+++ b/pagesections/ComponentInteraction.js
@@ -39,8 +39,8 @@ const ComponentInteraction = ( Base ) => class extends Base {
 	}
 
 	selectFirstSuggestedEntityOnEntitySelector() {
-		$( this.constructor.GENERAL_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).waitForVisible();
-		$( this.constructor.GENERAL_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).click();
+		$( this.constructor.OOUI_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).waitForVisible();
+		$( this.constructor.OOUI_SELECTORS.VISIBLE_ENTITY_SUGGESTION ).click();
 	}
 };
 

--- a/pagesections/main.statement.section.js
+++ b/pagesections/main.statement.section.js
@@ -47,7 +47,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( property );
 
-		this.selectSuggestedEntity( property );
+		this.selectFirstSuggestedEntity( property );
 
 		this.mainStatementsContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE
@@ -86,7 +86,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( referenceProperty );
 
-		this.selectSuggestedEntity( referenceProperty );
+		this.selectFirstSuggestedEntity( referenceProperty );
 
 		referencesContainer.waitForExist( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE );
 		referencesContainer.$(

--- a/pagesections/main.statement.section.js
+++ b/pagesections/main.statement.section.js
@@ -47,7 +47,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( property );
 
-		this.selectFirstSuggestedEntity();
+		this.selectFirstSuggestedEntityOnEntitySelector();
 
 		this.mainStatementsContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE
@@ -86,7 +86,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( referenceProperty );
 
-		this.selectFirstSuggestedEntity();
+		this.selectFirstSuggestedEntityOnEntitySelector();
 
 		referencesContainer.waitForExist( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE );
 		referencesContainer.$(

--- a/pagesections/main.statement.section.js
+++ b/pagesections/main.statement.section.js
@@ -47,7 +47,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( property );
 
-		this.selectSuggestedProperty( property );
+		this.selectSuggestedEntity( property );
 
 		this.mainStatementsContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE
@@ -86,7 +86,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( referenceProperty );
 
-		this.selectSuggestedProperty( referenceProperty );
+		this.selectSuggestedEntity( referenceProperty );
 
 		referencesContainer.waitForExist( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE );
 		referencesContainer.$(

--- a/pagesections/main.statement.section.js
+++ b/pagesections/main.statement.section.js
@@ -47,7 +47,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( property );
 
-		this.selectFirstSuggestedEntity( property );
+		this.selectFirstSuggestedEntity();
 
 		this.mainStatementsContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE
@@ -86,7 +86,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( referenceProperty );
 
-		this.selectFirstSuggestedEntity( referenceProperty );
+		this.selectFirstSuggestedEntity();
 
 		referencesContainer.waitForExist( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE );
 		referencesContainer.$(

--- a/pagesections/main.statement.section.js
+++ b/pagesections/main.statement.section.js
@@ -46,6 +46,9 @@ const MainStatementSection = ( Base ) => class extends Base {
 		this.mainStatementsContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( property );
+
+		this.selectSuggestedProperty( property );
+
 		this.mainStatementsContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE
 		).waitForVisible();
@@ -82,6 +85,8 @@ const MainStatementSection = ( Base ) => class extends Base {
 		referencesContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( referenceProperty );
+
+		this.selectSuggestedProperty( referenceProperty );
 
 		referencesContainer.waitForExist( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE );
 		referencesContainer.$(


### PR DESCRIPTION
As part of [T234322](https://phabricator.wikimedia.org/T234322), we have to select the property from the property suggester "manually" in our browser tests.

Example usage of this function to fix item.js browser test: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/541081/2/repo/tests/selenium/specs/item.js#38

On one hand, selecting that value should be scoped into this library since the suggester is ideally attached to the input element (which is inside item view in here).

On the other hand, property suggester instances on that page are not distinct to which element they are attached through any property or class, thus I had to use xpath and rely on only one property suggester instance to be active (visible) at any moment.

I feel okay with this decision of keeping it in this scope, even if the selector appears rather generic and uses xpath (for reasons that are not relevant to this library) for now.