### PR TITLE
Tainted References browser test fails locally with Error: Element not found

### DIFF
--- a/pagesections/main.statement.section.js
+++ b/pagesections/main.statement.section.js
@@ -182,7 +182,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 	 * @param {element} element
 	 */
 	clickEditOnStatementElement( element ) {
-		element.$( this.constructor.TOOLBAR_WIDGET_SELECTORS.EDIT_BUTTON ).waitForExist();
+		element.waitForVisible( this.constructor.TOOLBAR_WIDGET_SELECTORS.EDIT_BUTTON );
 		element.$( this.constructor.TOOLBAR_WIDGET_SELECTORS.EDIT_BUTTON ).click();
 	}
 

--- a/pagesections/main.statement.section.js
+++ b/pagesections/main.statement.section.js
@@ -182,7 +182,7 @@ const MainStatementSection = ( Base ) => class extends Base {
 	 * @param {element} element
 	 */
 	clickEditOnStatementElement( element ) {
-		element.waitForVisible( this.constructor.TOOLBAR_WIDGET_SELECTORS.EDIT_BUTTON );
+		element.waitForExist( this.constructor.TOOLBAR_WIDGET_SELECTORS.EDIT_BUTTON );
 		element.$( this.constructor.TOOLBAR_WIDGET_SELECTORS.EDIT_BUTTON ).click();
 	}
 


### PR DESCRIPTION
Tainted References browser test fails locally with Error: Element not located on page.

For a reason still unknown, element.$(...EDIT_BUTTON).waitForExist(); does not wait
replacing that with element.waitForExist(...EDIT_BUTTON ) actually does the expected waiting.

Note that this behaviour happens both with waitForExist() and waitForVisible()

Bug: T244589
Bug: T243817