### PR TITLE
Prepare 3.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wdio-wikibase",
-	"version": "2.3.1",
+	"version": "3.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wdio-wikibase",
-	"version": "2.3.1",
+	"version": "3.0.0",
 	"description": "WebdriverIO plugin for testing a Wikibase repo.",
 	"homepage": "https://github.com/wmde/wdio-wikibase",
 	"license": "GPL-2.0+",


### PR DESCRIPTION
Major version because it changes the (previously implicit) peer
dependency from wdio 4 to wdio 5.

Bug: T244981