### PR TITLE
Use same user/password env vars as mw browser tests

### DIFF
--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -95,8 +95,8 @@ class WikibaseApi {
 		} ).then( ( getEntitiesResponse ) => {
 			entityTitle = getEntitiesResponse.entities[ entityId ].title;
 			return bot.loginGetEditToken( {
-				username: browser.config.username,
-				password: browser.config.password
+				username: browser.config.mwUser,
+				password: browser.config.mwPwd
 			} );
 		} ).then( () => {
 			return bot.request( {


### PR DESCRIPTION
This changed in core for some reason during the migration from wdio 4 to
wdio 5. With this adjusted we can actually go back to using
LoginPage.loginAdmin without the workaround.

https://gerrit.wikimedia.org/g/mediawiki/core/+/46776c620ea230f068574f7f5988357e879dfb8c/tests/selenium/wdio.conf.js#29