### PR TITLE
Upgrade to wdio6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# IDE files
+.idea

--- a/pageobjects/item.page.js
+++ b/pageobjects/item.page.js
@@ -89,18 +89,18 @@ class ItemPage extends PageMixture {
 
 	editItemDescription( description ) {
 
-		this.editButton.waitForExist( 3000 );
+		this.editButton.waitForExist( { timeout: 3000 } );
 		browser.pause( 100 );
 		this.editButton.click();
 		this.descriptionInputField.waitForExist();
 		this.descriptionInputField.setValue( description );
-		this.saveButton.waitForExist( 1000 );
+		this.saveButton.waitForExist( { timeout: 1000 } );
 		this.saveButton.click();
 	}
 
 	goToPreviousRevision() {
 		this.recentChanges.click();
-		this.lastChangeHistory.waitForExist( 1000 );
+		this.lastChangeHistory.waitForExist( { timeout: 1000 } );
 		this.lastChangeHistory.click();
 		const revisionList = $( this.constructor.ITEM_WIDGET_SELECTORS.REVISION );
 		revisionList.$( this.constructor.ITEM_WIDGET_SELECTORS.REVISION_DATE_LINK ).waitForExist();

--- a/pagesections/ComponentInteraction.js
+++ b/pagesections/ComponentInteraction.js
@@ -17,13 +17,13 @@ const ComponentInteraction = ( Base ) => class extends Base {
 
 	setValueOnLookupElement( element, value ) {
 		element.$( 'input' ).setValue( value );
-		$( 'body' ).waitForDisplayed( this.constructor.OOUI_SELECTORS.LOOKUP_OPTION_WIDGET );
+		$( 'body' ).$( this.constructor.OOUI_SELECTORS.LOOKUP_OPTION_WIDGET ).waitForDisplayed();
 		$( this.constructor.OOUI_SELECTORS.LOOKUP_OPTION_WIDGET ).click();
 	}
 
 	setSingleValueOnMultiselectElement( element, value ) {
 		element.$( 'input' ).setValue( value );
-		element.waitForDisplayed( this.constructor.OOUI_SELECTORS.MULTI_OPTION_WIDGET );
+		element.$( this.constructor.OOUI_SELECTORS.MULTI_OPTION_WIDGET ).waitForDisplayed();
 		element.$( this.constructor.OOUI_SELECTORS.MULTI_OPTION_WIDGET ).click();
 	}
 

--- a/pagesections/main.statement.section.js
+++ b/pagesections/main.statement.section.js
@@ -69,18 +69,18 @@ const MainStatementSection = ( Base ) => class extends Base {
 
 		if ( !referencesContainer.isDisplayed( this.constructor.TOOLBAR_WIDGET_SELECTORS.ADD_BUTTON ) ) {
 			statement.$( '.wikibase-statementview-references-heading' ).click();
-			statement.waitForDisplayed( '.wikibase-statementview-references' );
-			referencesContainer.waitForDisplayed( this.constructor.TOOLBAR_WIDGET_SELECTORS.ADD_BUTTON );
+			statement.$( '.wikibase-statementview-references' ).waitForDisplayed();
+			referencesContainer.$( this.constructor.TOOLBAR_WIDGET_SELECTORS.ADD_BUTTON ).waitForDisplayed();
 		}
 		referencesContainer.$( this.constructor.TOOLBAR_WIDGET_SELECTORS.ADD_BUTTON ).click();
-		referencesContainer.waitForDisplayed( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY );
+		referencesContainer.$( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY ).waitForDisplayed();
 		referencesContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_PROPERTY
 		).setValue( referenceProperty );
 
 		this.selectFirstSuggestedEntityOnEntitySelector();
 
-		referencesContainer.waitForExist( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE );
+		referencesContainer.$( this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE ).waitForExist();
 		referencesContainer.$(
 			this.constructor.STATEMENT_WIDGET_SELECTORS.EDIT_INPUT_VALUE
 		).setValue( referenceValue );


### PR DESCRIPTION
Finalize (hopefully) the wdio6 port on top of the volunteer contribution 3cb784e.

See https://webdriver.io/blog/2020/03/26/webdriverio-v6-released.html#how-to-update-4

As demonstrated in
* lexeme - https://gerrit.wikimedia.org/r/c/mediawiki/extensions/WikibaseLexeme/+/604468/14
* wikibase, termbox - https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/604459/15 (contains https://gerrit.wikimedia.org/r/c/wikibase/termbox/+/622327/)

Once this is merged, a 4.0.0 release of this lib and an update of the linked patches to use it is due.

Bug: https://phabricator.wikimedia.org/T261218