### PR TITLE
package: widen webdriverio peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wdio-wikibase",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "WebdriverIO plugin for testing a Wikibase repo.",
 	"homepage": "https://github.com/wmde/wdio-wikibase",
 	"bugs": "https://phabricator.wikimedia.org/",
@@ -23,7 +23,7 @@
 	"peerDependencies": {
 		"mwbot": "^1.0.10",
 		"wdio-mediawiki": "^1.0.0",
-		"webdriverio": "~6.0"
+		"webdriverio": "^6.0"
 	},
 	"devDependencies": {
 		"eslint": "^6.2.2",


### PR DESCRIPTION
We should be compatible with all minor versions of webdriverio 6. Also
verified with the original author of the tilde that there was no deeper
meaning in being less permissive.

As this makes us more allowing with respect to the peer dep, I don't
consider this anything but a patch.