### PR TITLE
Fix WikibaseApi.createItem: Don't set labels to null

### DIFF
--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -13,7 +13,7 @@ class WikibaseApi {
 	 */
 	createItem( label, data ) {
 		const itemData = {};
-		let labels = null;
+		let labels = {};
 
 		if ( typeof label === 'object' ) {
 			labels = label;


### PR DESCRIPTION
Using null will make the Wikibase API fail with:
"not-recognized-array: An array was expected, but not recognized."