### PR TITLE
Release wdio-wikibase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "wdio-wikibase",
 			"version": "5.1.0",
 			"license": "GPL-2.0+",
 			"devDependencies": {
@@ -1796,8 +1797,9 @@
 			}
 		},
 		"node_modules/glob-parent": {
-			"version": "5.1.1",
-			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"dev": true,
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -5161,8 +5163,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.1.1",
-			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"


### PR DESCRIPTION
To remove Dependabot's message ` Dependabot cannot update glob-parent to a non-vulnerable version`. I updated glob-parent before I can release.