### PR TITLE
Reuse bot object in API and optionally use chronology protector

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
 		"$": false
 	},
 	"parserOptions": {
-		"ecmaVersion": 6
+		"ecmaVersion": 2017
 	},
 	"rules": {
 		"max-len": [ "error", 120 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"license": "GPL-2.0+",
 			"devDependencies": {
 				"eslint": "^6.2.2",
-				"eslint-config-wikimedia": "^0.13.1"
+				"eslint-config-wikimedia": "^0.13.1",
+				"request": "^2.88.2"
 			},
 			"engines": {
 				"node": ">=8.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	},
 	"devDependencies": {
 		"eslint": "^6.2.2",
-		"eslint-config-wikimedia": "^0.13.1"
+		"eslint-config-wikimedia": "^0.13.1",
+		"request": "^2.88.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wdio-wikibase",
-	"version": "5.1.0",
+	"version": "5.2.0",
 	"description": "WebdriverIO plugin for testing a Wikibase repo.",
 	"homepage": "https://github.com/wmde/wdio-wikibase",
 	"bugs": "https://phabricator.wikimedia.org/",


### PR DESCRIPTION
Using the chronology protector should prevent some browser test failures when running against beta and the replica hasn't caught up yet.

TODO: Somehow try this out in my local browser tests

Bug: [T277862](https://phabricator.wikimedia.org/T277862)
Bug: [T284443](https://phabricator.wikimedia.org/T284443)