### PR TITLE
Prepare v6 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wdio-wikibase",
-	"version": "5.2.0",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wdio-wikibase",
-			"version": "5.2.0",
+			"version": "6.0.0",
 			"license": "GPL-2.0+",
 			"devDependencies": {
 				"eslint": "^6.2.2",
@@ -14,7 +14,7 @@
 				"request": "^2.88.2"
 			},
 			"engines": {
-				"node": ">=8.0"
+				"node": ">=16.0"
 			},
 			"peerDependencies": {
 				"mwbot": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wdio-wikibase",
-	"version": "5.2.0",
+	"version": "6.0.0",
 	"description": "WebdriverIO plugin for testing a Wikibase repo.",
 	"homepage": "https://github.com/wmde/wdio-wikibase",
 	"bugs": "https://phabricator.wikimedia.org/",
@@ -15,7 +15,7 @@
 		"wdio-plugin"
 	],
 	"engines": {
-		"node": ">=8.0"
+		"node": ">=16.0"
 	},
 	"scripts": {
 		"test": "eslint ."


### PR DESCRIPTION
This is a new major version release since the library was migrated from sync to async mode.