### PR TITLE
Ensure `mediawiki.cookie` is loaded before calls to `mw.cookie`

### DIFF
--- a/pageobjects/entity.page.js
+++ b/pageobjects/entity.page.js
@@ -5,8 +5,11 @@ class EntityPage extends Page {
 	async open( entityId ) {
 		await super.openTitle( `Special:EntityPage/${entityId}` );
 
-		await browser.execute( () => {
-			mw.cookie.set( 'wikibase-no-anonymouseditwarning', 'true' ); // eslint-disable-line no-undef
+		await browser.executeAsync( ( done ) => {
+			mw.loader.using( 'mediawiki.cookie' ).then( () => { // eslint-disable-line no-undef
+				mw.cookie.set( 'wikibase-no-anonymouseditwarning', 'true' ); // eslint-disable-line no-undef
+				done();
+			} );
 		} );
 	}
 }


### PR DESCRIPTION
We see some intermittent test failures in selenium test cases that use the `entity.page.js` page object of the form:

Cannot read property 'set' of undefined

coming from the call to `mw.cookie.set`. Wrap the call in a call to `mw.loader` to ensure that `mw.cookie` has been loaded before the `set` call is made.

Bug: T365646