### PR TITLE
EntityPage: Wait for MediaWiki to be ready

### DIFF
--- a/pageobjects/entity.page.js
+++ b/pageobjects/entity.page.js
@@ -1,10 +1,12 @@
 const Page = require( 'wdio-mediawiki/Page' );
+const Util = require( 'wdio-mediawiki/Util' );
 
 class EntityPage extends Page {
 
 	async open( entityId ) {
 		await super.openTitle( `Special:EntityPage/${entityId}` );
 
+		await Util.waitForModuleState( 'mediawiki.base' ); // wait for mediawiki to be ready
 		await browser.executeAsync( ( done ) => {
 			mw.loader.using( 'mediawiki.cookie' ).then( () => { // eslint-disable-line no-undef
 				mw.cookie.set( 'wikibase-no-anonymouseditwarning', 'true' ); // eslint-disable-line no-undef


### PR DESCRIPTION
We've observed test failures indicating that MediaWiki's JS hadn't fully loaded yet after using EntityPage.open(). Waiting for the mediawiki.base ResourceLoader  module should prevent that.

Bug: [T370139](https://phabricator.wikimedia.org/T370139)

Solution inspired by [Lucas' comment](https://phabricator.wikimedia.org/T368454#10001579).

Patch re-enabling the test: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/1060461 which is currently pointing to this branch, will unWIP and update once a new version of wdio-wikibase is tagged

Other places doing `await Util.waitForModuleState( 'mediawiki.base' )`: https://codesearch.wmcloud.org/search/?q=waitForModuleState%5C%28+%27mediawiki.base%27+%5C%29&files=&excludeFiles=&repos=
