### PR TITLE
Wait longer for `mediawiki.base` to be ready

### DIFF
--- a/pageobjects/entity.page.js
+++ b/pageobjects/entity.page.js
@@ -6,7 +6,7 @@ class EntityPage extends Page {
 	async open( entityId ) {
 		await super.openTitle( `Special:EntityPage/${entityId}` );
 
-		await Util.waitForModuleState( 'mediawiki.base' ); // wait for mediawiki to be ready
+		await Util.waitForModuleState( 'mediawiki.base', 'ready', 10000 ); // wait for mediawiki to be ready
 		await browser.executeAsync( ( done ) => {
 			mw.loader.using( 'mediawiki.cookie' ).then( () => { // eslint-disable-line no-undef
 				mw.cookie.set( 'wikibase-no-anonymouseditwarning', 'true' ); // eslint-disable-line no-undef


### PR DESCRIPTION
The default is 5000 (milliseconds); let’s try doubling it.

Bug: [T388228](https://phabricator.wikimedia.org/T388228)