### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v5
         with:
-          node-version: '16.x'
+          node-version: 20
       - name: Install
         run: npm ci
       - name: Test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,10 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v5
         with:
-          node-version: "16.x"
-          cache: npm
+          node-version: 20
       - name: install
         run: npm install
       - name: Test


### PR DESCRIPTION
Bump the setup-node action (note that v5 enables caching by default) and the Node version inside (Node 20 is currently used in Wikimedia CI), and in publish.yml also unpin the checkout action to match push.yml.