### PR TITLE
Bump the version to 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wdio-wikibase",
-	"version": "6.0.3",
+	"version": "6.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wdio-wikibase",
-			"version": "6.0.3",
+			"version": "6.1.0",
 			"license": "GPL-2.0+",
 			"devDependencies": {
 				"eslint-config-wikimedia": "^0.31.0",
@@ -18,7 +18,7 @@
 			"peerDependencies": {
 				"mwbot": "^2.0.0",
 				"wdio-mediawiki": "^5.1.0",
-				"webdriverio": "^7.0 || ^8.16"
+				"webdriverio": "^7.0 || ^8.16 || ^9"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wdio-wikibase",
-	"version": "6.0.3",
+	"version": "6.1.0",
 	"description": "WebdriverIO plugin for testing a Wikibase repo.",
 	"homepage": "https://github.com/wmde/wdio-wikibase",
 	"bugs": "https://phabricator.wikimedia.org/",


### PR DESCRIPTION
It’s been over a year since the last release and we bumped wdio-mediawiki by three majors, I think that’s enough to justify a minor rather than patch bump here.