### PR TITLE
Downgrade wdio-mediawiki to v3 and bump version to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wdio-wikibase",
-	"version": "6.1.0",
+	"version": "6.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wdio-wikibase",
-			"version": "6.1.0",
+			"version": "6.3.0",
 			"license": "GPL-2.0+",
 			"devDependencies": {
 				"eslint-config-wikimedia": "^0.31.0",
@@ -17,7 +17,7 @@
 			},
 			"peerDependencies": {
 				"mwbot": "^2.0.0",
-				"wdio-mediawiki": "^5.1.0",
+				"wdio-mediawiki": "^3.0.1",
 				"webdriverio": "^7.0 || ^8.16 || ^9"
 			}
 		},
@@ -5354,9 +5354,9 @@
 			"dev": true
 		},
 		"node_modules/wdio-mediawiki": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-5.1.0.tgz",
-			"integrity": "sha512-W4uCwveUxZT19uFDSF6clNDo13H74z5c7HKBqbJEgWHw6v+OAjm06lqo71hI6okQ/mbNNHfeJJ1wkRm3qVWTeQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-3.0.1.tgz",
+			"integrity": "sha512-JnW3rOwRdS+f/qC4JCswA0Z3y1wPXb3vuNchoRIYsGeWuljxx69i7l3FnCiHediio1Ul0dTOCqXHdbheqQpLsQ==",
 			"peer": true,
 			"dependencies": {
 				"mwbot": "2.1.3"
@@ -9440,9 +9440,9 @@
 			}
 		},
 		"wdio-mediawiki": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-5.1.0.tgz",
-			"integrity": "sha512-W4uCwveUxZT19uFDSF6clNDo13H74z5c7HKBqbJEgWHw6v+OAjm06lqo71hI6okQ/mbNNHfeJJ1wkRm3qVWTeQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-3.0.1.tgz",
+			"integrity": "sha512-JnW3rOwRdS+f/qC4JCswA0Z3y1wPXb3vuNchoRIYsGeWuljxx69i7l3FnCiHediio1Ul0dTOCqXHdbheqQpLsQ==",
 			"peer": true,
 			"requires": {
 				"mwbot": "2.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wdio-wikibase",
-	"version": "6.1.0",
+	"version": "6.3.0",
 	"description": "WebdriverIO plugin for testing a Wikibase repo.",
 	"homepage": "https://github.com/wmde/wdio-wikibase",
 	"bugs": "https://phabricator.wikimedia.org/",
@@ -22,7 +22,7 @@
 	},
 	"peerDependencies": {
 		"mwbot": "^2.0.0",
-		"wdio-mediawiki": "^5.1.0",
+		"wdio-mediawiki": "^3.0.1",
 		"webdriverio": "^7.0 || ^8.16 || ^9"
 	},
 	"devDependencies": {


### PR DESCRIPTION
According to discussion on Phabricator (specifically [T406844#11284701](https://phabricator.wikimedia.org/T406844#11284701)), we should first upgrade to wdio-mediawiki v3 and update Wikibase to WebdriverIO v8; then wdio-mediawiki v4 with WebdriverIO v9; and only then wdio-mediawiki v5 with ECMAScript modules.

Bump the version in the same commit so that we can release this quickly. I’m skipping version 6.2 because I think making our minor version match the wdio-mediawiki major version (only until we’re done with this upgrade) should be a useful mnemonic.

Bug: [T406844](https://phabricator.wikimedia.org/T406844)

----

(If you think going from version 6.1 straight to 6.3 is too confusing, I’m happy to drop that part and make this version 6.2.0 after all.)