### PR TITLE
Update `initialize()` for wdio v8+

### DIFF
--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -10,32 +10,29 @@ class WikibaseApi {
 	 *
 	 * @param {string} [cpPosIndex] The value of the cpPosIndex browser cookie.
 	 * Optional, but strongly recommended to have chronology protection.
-	 * @param {string} [mwUser] Override mwUser argument.
-	 * Implemented due to the removal of mwUser from browser.options,
-	 * the replacement for browser.config.
-	 * @param {string} [mwPwd] Override mwPwd argument.
-	 * Implemented due to the removal of mwPwd from browser.options,
-	 * the replacement for browser.config.
+	 * @param {string} [mwUser] Override browser.options.capabilities[ 'mw:user' ]
+	 * (user name for logging into MediaWiki).
+	 * @param {string} [mwPwd] Override browser.options.capabilities[ 'mw:pwd' ]
+	 * (password for logging into MediaWiki).
 	 * @return {Promise<MWBot>} resolving with MWBot
 	 */
 	async initialize( cpPosIndex, mwUser, mwPwd ) {
-		const config = Object.assign( browser.config || {}, browser.options || {} );
 		const jar = request.jar();
 		if ( cpPosIndex ) {
 			const cookie = request.cookie( `cpPosIndex=${ cpPosIndex }` );
-			jar.setCookie( cookie, config.baseUrl );
+			jar.setCookie( cookie, browser.options.baseUrl );
 		}
 		const bot = new MWBot(
 			{
-				apiUrl: `${ config.baseUrl }/api.php`
+				apiUrl: `${ browser.options.baseUrl }/api.php`
 			},
 			{
 				jar: jar
 			}
 		);
 		await bot.loginGetEditToken( {
-			username: mwUser || config.mwUser,
-			password: mwPwd || config.mwPwd
+			username: mwUser || browser.options.capabilities[ 'mw:user' ],
+			password: mwPwd || browser.options.capabilities[ 'mw:pwd' ]
 		} );
 		this.bot = bot;
 


### PR DESCRIPTION
This was previously updated in #72; at the time, MediaWiki didn’t support WebdriverIO v8 yet and it was unclear where to get the user name and password from, so `initialize()` gained support for having them passed in as explicit parameters, while still falling back to try reading them from both `browser.config` (wdio v7) and `browser.options` (never worked but didn’t hurt either). However, this has now changed: MediaWiki supports wdio v8 and settled on the pattern of putting the user name and password into the capabilities object, where we’re still allowed to define custom properties (as long as their names contain a colon, I think). Update `initialize()` to read the username and password from there. The explicit `mwUser` and `mwPwd` parameters are kept, because they shouldn’t hurt, even though I expect we won’t use them anymore in the long term; meanwhile, reading from `browser.config` is removed (we no longer support wdio v7), as is reading from `browser.options` without `.capabilities`.

Bug: [T406844](https://phabricator.wikimedia.org/T406844)