### PR TITLE
Update wdio-mediawiki to latest 6 that replaces mwbot

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,7 @@
 	},
 	"rules": {
 		"max-len": [ "error", 120 ],
-		"jsdoc/no-undefined-types": [ "error", { "definedTypes": [ "Base", "WebdriverIO", "int" ] } ]
+		"jsdoc/no-undefined-types": [ "error", { "definedTypes": [ "Api", "Base", "WebdriverIO", "int" ] } ]
 	},
 	"overrides": [
 		{

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,13 @@
 			"version": "7.0.0",
 			"license": "GPL-2.0+",
 			"devDependencies": {
-				"eslint-config-wikimedia": "^0.31.0",
-				"request": "^2.88.2"
+				"eslint-config-wikimedia": "^0.31.0"
 			},
 			"engines": {
 				"node": ">=16.0"
 			},
 			"peerDependencies": {
-				"mwbot": "^2.0.0",
-				"wdio-mediawiki": "^5.0.0",
+				"wdio-mediawiki": "^6.0.0",
 				"webdriverio": "^9"
 			}
 		},
@@ -1165,6 +1163,7 @@
 		"node_modules/ajv": {
 			"version": "6.12.4",
 			"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -1402,22 +1401,6 @@
 				"dequal": "^2.0.3"
 			}
 		},
-		"node_modules/asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dependencies": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"node_modules/assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/ast-metadata-inferer": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.1.tgz",
@@ -1444,24 +1427,6 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
 			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
 			"peer": true
-		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"node_modules/aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
 		"node_modules/b4a": {
 			"version": "1.7.3",
@@ -1610,20 +1575,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dependencies": {
-				"tweetnacl": "^0.14.3"
-			}
-		},
-		"node_modules/bluebird": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-			"peer": true
-		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1739,11 +1690,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			]
-		},
-		"node_modules/caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -1873,26 +1819,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
-		"node_modules/colors": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-			"peer": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/commander": {
 			"version": "9.5.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -1988,7 +1914,8 @@
 		"node_modules/core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"peer": true
 		},
 		"node_modules/crc-32": {
 			"version": "1.2.2",
@@ -2120,17 +2047,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dependencies": {
-				"assert-plus": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -2200,14 +2116,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/dequal": {
@@ -2307,15 +2215,6 @@
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"peer": true
-		},
-		"node_modules/ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dependencies": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
 		},
 		"node_modules/edge-paths": {
 			"version": "3.0.5",
@@ -2509,6 +2408,7 @@
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -3369,11 +3269,6 @@
 				"bare-events": "^2.7.0"
 			}
 		},
-		"node_modules/extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-		},
 		"node_modules/extract-zip": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -3394,17 +3289,10 @@
 				"@types/yauzl": "^2.9.1"
 			}
 		},
-		"node_modules/extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"engines": [
-				"node >=0.6.0"
-			]
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"node_modules/fast-fifo": {
 			"version": "1.3.2",
@@ -3442,7 +3330,8 @@
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
@@ -3580,27 +3469,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 0.12"
 			}
 		},
 		"node_modules/formdata-polyfill": {
@@ -3812,14 +3680,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dependencies": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"node_modules/glob": {
 			"version": "7.1.6",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
@@ -3888,48 +3748,6 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
-		},
-		"node_modules/har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/har-validator": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"deprecated": "this library is no longer supported",
-			"dependencies": {
-				"ajv": "^6.12.3",
-				"har-schema": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/has-ansi/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -4014,20 +3832,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dependencies": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
-			},
-			"engines": {
-				"node": ">=0.8",
-				"npm": ">=1.3.7"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -4251,11 +4055,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4265,11 +4064,6 @@
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-		},
-		"node_modules/isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"node_modules/jackspeak": {
 			"version": "3.4.3",
@@ -4313,11 +4107,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-		},
 		"node_modules/jsdoc-type-pratt-parser": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
@@ -4351,39 +4140,16 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
-		"node_modules/json-schema": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
-		},
-		"node_modules/json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-		},
-		"node_modules/jsprim": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-			"dependencies": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.4.0",
-				"verror": "1.10.0"
-			},
-			"engines": {
-				"node": ">=0.6.0"
-			}
 		},
 		"node_modules/jszip": {
 			"version": "3.10.1",
@@ -4642,25 +4408,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/mime-db": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-			"integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.31",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-			"integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-			"dependencies": {
-				"mime-db": "1.48.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -4682,15 +4429,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4705,21 +4443,6 @@
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
 			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
 			"peer": true
-		},
-		"node_modules/mwbot": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/mwbot/-/mwbot-2.1.3.tgz",
-			"integrity": "sha512-ULQWIfRWfh0WJKmqcapshk/5VNU1KEfrI7+hLeO3WoyuTGBVlhr3eE9TEyc4Q46vmztR6YHlaA6TmDGQr7/akg==",
-			"peer": true,
-			"dependencies": {
-				"bluebird": "^3.7.2",
-				"request": "^2.88.2",
-				"semlog": "^0.6.10",
-				"semver": "^7.3.8"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -4801,14 +4524,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
-			}
-		},
-		"node_modules/oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/once": {
@@ -5075,11 +4790,6 @@
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"peer": true
 		},
-		"node_modules/performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5127,19 +4837,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/prettyjson": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-			"integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
-			"peer": true,
-			"dependencies": {
-				"colors": "^1.1.2",
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"prettyjson": "bin/prettyjson"
 			}
 		},
 		"node_modules/process": {
@@ -5212,11 +4909,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"peer": true
 		},
-		"node_modules/psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-		},
 		"node_modules/pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -5230,6 +4922,7 @@
 		"node_modules/punycode": {
 			"version": "2.1.1",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -5251,14 +4944,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/qs": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-			"engines": {
-				"node": ">=0.6"
 			}
 		},
 		"node_modules/query-selector-shadow-dom": {
@@ -5401,37 +5086,6 @@
 			"dev": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
-			}
-		},
-		"node_modules/request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-			"dependencies": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/require-directory": {
@@ -5595,7 +5249,8 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"peer": true
 		},
 		"node_modules/safe-regex": {
 			"version": "2.1.1",
@@ -5627,72 +5282,8 @@
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"node_modules/semlog": {
-			"version": "0.6.10",
-			"resolved": "https://registry.npmjs.org/semlog/-/semlog-0.6.10.tgz",
-			"integrity": "sha1-DyJa6o6zwvJM6TWNhnjQ9Bp/4Fs=",
-			"peer": true,
-			"dependencies": {
-				"chalk": "^1.1.3",
-				"prettyjson": "^1.1.3"
-			}
-		},
-		"node_modules/semlog/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/semlog/node_modules/ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/semlog/node_modules/chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/semlog/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/semlog/node_modules/supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"peer": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"peer": true
 		},
 		"node_modules/semver": {
 			"version": "7.7.3",
@@ -5893,30 +5484,6 @@
 				"node": ">= 10.x"
 			}
 		},
-		"node_modules/sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dependencies": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			},
-			"bin": {
-				"sshpk-conv": "bin/sshpk-conv",
-				"sshpk-sign": "bin/sshpk-sign",
-				"sshpk-verify": "bin/sshpk-verify"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/streamx": {
 			"version": "2.23.0",
 			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -6089,18 +5656,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"dependencies": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/ts-api-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6140,22 +5695,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"peer": true
-		},
-		"node_modules/tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -6260,6 +5799,7 @@
 		"node_modules/uri-js": {
 			"version": "4.2.2",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -6284,15 +5824,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
-		"node_modules/uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-			"bin": {
-				"uuid": "bin/uuid"
-			}
-		},
 		"node_modules/validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -6311,19 +5842,6 @@
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"engines": [
-				"node >=0.6.0"
-			],
-			"dependencies": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
 			}
 		},
 		"node_modules/vue-eslint-parser": {
@@ -6397,13 +5915,10 @@
 			}
 		},
 		"node_modules/wdio-mediawiki": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-5.1.0.tgz",
-			"integrity": "sha512-W4uCwveUxZT19uFDSF6clNDo13H74z5c7HKBqbJEgWHw6v+OAjm06lqo71hI6okQ/mbNNHfeJJ1wkRm3qVWTeQ==",
-			"peer": true,
-			"dependencies": {
-				"mwbot": "2.1.3"
-			}
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-6.1.0.tgz",
+			"integrity": "sha512-fO5uA4AoVsr8eNl9VxkTQ+HF2Jhs2zGfasoofXgmQSvJvsZuehBJhF3DjWbFxPWZUfzal8iO1RjVT7cjYZoXnw==",
+			"peer": true
 		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
@@ -7582,6 +7097,7 @@
 		"ajv": {
 			"version": "6.12.4",
 			"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -7752,19 +7268,6 @@
 				"dequal": "^2.0.3"
 			}
 		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
 		"ast-metadata-inferer": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.1.tgz",
@@ -7788,21 +7291,6 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
 			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
 			"peer": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-		},
-		"aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
 		"b4a": {
 			"version": "1.7.3",
@@ -7891,20 +7379,6 @@
 			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
 			"peer": true
 		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
-		},
-		"bluebird": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-			"peer": true
-		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -7971,11 +7445,6 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
 			"integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
 			"dev": true
-		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -8069,20 +7538,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
-		"colors": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-			"peer": true
-		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commander": {
 			"version": "9.5.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -8150,7 +7605,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"peer": true
 		},
 		"crc-32": {
 			"version": "1.2.2",
@@ -8240,14 +7696,6 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"dev": true
 		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"data-uri-to-buffer": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -8297,11 +7745,6 @@
 				"escodegen": "^2.1.0",
 				"esprima": "^4.0.1"
 			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"dequal": {
 			"version": "2.0.3",
@@ -8373,15 +7816,6 @@
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"peer": true
-		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
 		},
 		"edge-paths": {
 			"version": "3.0.5",
@@ -8523,7 +7957,8 @@
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "2.1.0",
@@ -9100,11 +8535,6 @@
 				"bare-events": "^2.7.0"
 			}
 		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-		},
 		"extract-zip": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -9117,14 +8547,10 @@
 				"yauzl": "^2.10.0"
 			}
 		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"fast-fifo": {
 			"version": "1.3.2",
@@ -9158,7 +8584,8 @@
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -9256,21 +8683,6 @@
 			"requires": {
 				"cross-spawn": "^7.0.6",
 				"signal-exit": "^4.0.1"
-			}
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
 			}
 		},
 		"formdata-polyfill": {
@@ -9423,14 +8835,6 @@
 				"debug": "^4.3.4"
 			}
 		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"glob": {
 			"version": "7.1.6",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
@@ -9484,37 +8888,6 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-		},
-		"har-validator": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"requires": {
-				"ajv": "^6.12.3",
-				"har-schema": "^2.0.0"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"peer": true,
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"peer": true
-				}
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -9578,16 +8951,6 @@
 					"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 					"peer": true
 				}
-			}
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
@@ -9733,11 +9096,6 @@
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"peer": true
 		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -9747,11 +9105,6 @@
 		"isexe": {
 			"version": "2.0.0",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"jackspeak": {
 			"version": "3.4.3",
@@ -9784,11 +9137,6 @@
 				"argparse": "^2.0.1"
 			}
 		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-		},
 		"jsdoc-type-pratt-parser": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
@@ -9813,36 +9161,16 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
-		"json-schema": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-		},
-		"jsprim": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.4.0",
-				"verror": "1.10.0"
-			}
 		},
 		"jszip": {
 			"version": "3.10.1",
@@ -10062,19 +9390,6 @@
 				}
 			}
 		},
-		"mime-db": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-			"integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
-		},
-		"mime-types": {
-			"version": "2.1.31",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-			"integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-			"requires": {
-				"mime-db": "1.48.0"
-			}
-		},
 		"min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -10090,12 +9405,6 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
-		"minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"peer": true
-		},
 		"minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -10107,18 +9416,6 @@
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
 			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
 			"peer": true
-		},
-		"mwbot": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/mwbot/-/mwbot-2.1.3.tgz",
-			"integrity": "sha512-ULQWIfRWfh0WJKmqcapshk/5VNU1KEfrI7+hLeO3WoyuTGBVlhr3eE9TEyc4Q46vmztR6YHlaA6TmDGQr7/akg==",
-			"peer": true,
-			"requires": {
-				"bluebird": "^3.7.2",
-				"request": "^2.88.2",
-				"semlog": "^0.6.10",
-				"semver": "^7.3.8"
-			}
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -10177,11 +9474,6 @@
 			"requires": {
 				"boolbase": "^1.0.0"
 			}
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -10387,11 +9679,6 @@
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"peer": true
 		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
 		"picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10425,16 +9712,6 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
-		},
-		"prettyjson": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-			"integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
-			"peer": true,
-			"requires": {
-				"colors": "^1.1.2",
-				"minimist": "^1.2.0"
-			}
 		},
 		"process": {
 			"version": "0.11.10",
@@ -10493,11 +9770,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"peer": true
 		},
-		"psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -10510,7 +9782,8 @@
 		},
 		"punycode": {
 			"version": "2.1.1",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"puppeteer-core": {
 			"version": "24.30.0",
@@ -10527,11 +9800,6 @@
 				"webdriver-bidi-protocol": "0.3.8",
 				"ws": "^8.18.3"
 			}
-		},
-		"qs": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
 		},
 		"query-selector-shadow-dom": {
 			"version": "1.0.1",
@@ -10642,33 +9910,6 @@
 				}
 			}
 		},
-		"request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
-		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10766,7 +10007,8 @@
 		"safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"peer": true
 		},
 		"safe-regex": {
 			"version": "2.1.1",
@@ -10788,59 +10030,8 @@
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"semlog": {
-			"version": "0.6.10",
-			"resolved": "https://registry.npmjs.org/semlog/-/semlog-0.6.10.tgz",
-			"integrity": "sha1-DyJa6o6zwvJM6TWNhnjQ9Bp/4Fs=",
-			"peer": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"prettyjson": "^1.1.3"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"peer": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"peer": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"peer": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"peer": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"peer": true
-				}
-			}
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"peer": true
 		},
 		"semver": {
 			"version": "7.7.3",
@@ -10987,22 +10178,6 @@
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
 			"peer": true
 		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
 		"streamx": {
 			"version": "2.23.0",
 			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -11127,15 +10302,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"requires": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			}
-		},
 		"ts-api-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -11157,19 +10323,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"peer": true
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -11231,6 +10384,7 @@
 		"uri-js": {
 			"version": "4.2.2",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -11252,11 +10406,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
-		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -11277,16 +10426,6 @@
 						"spdx-license-ids": "^3.0.0"
 					}
 				}
-			}
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
 			}
 		},
 		"vue-eslint-parser": {
@@ -11335,13 +10474,10 @@
 			}
 		},
 		"wdio-mediawiki": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-5.1.0.tgz",
-			"integrity": "sha512-W4uCwveUxZT19uFDSF6clNDo13H74z5c7HKBqbJEgWHw6v+OAjm06lqo71hI6okQ/mbNNHfeJJ1wkRm3qVWTeQ==",
-			"peer": true,
-			"requires": {
-				"mwbot": "2.1.3"
-			}
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-6.1.0.tgz",
+			"integrity": "sha512-fO5uA4AoVsr8eNl9VxkTQ+HF2Jhs2zGfasoofXgmQSvJvsZuehBJhF3DjWbFxPWZUfzal8iO1RjVT7cjYZoXnw==",
+			"peer": true
 		},
 		"web-streams-polyfill": {
 			"version": "3.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"node": ">=16.0"
 			},
 			"peerDependencies": {
-				"wdio-mediawiki": "^6.0.0",
+				"wdio-mediawiki": "^6.4.0",
 				"webdriverio": "^9"
 			}
 		},
@@ -5915,9 +5915,9 @@
 			}
 		},
 		"node_modules/wdio-mediawiki": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-6.1.0.tgz",
-			"integrity": "sha512-fO5uA4AoVsr8eNl9VxkTQ+HF2Jhs2zGfasoofXgmQSvJvsZuehBJhF3DjWbFxPWZUfzal8iO1RjVT7cjYZoXnw==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-6.4.0.tgz",
+			"integrity": "sha512-aTkgHUF+rhLqnI2XiM+/fwgEitKU0cJcWXoIitrHxkt+07XYqvrgkUN1zcbETy5RGCGvf+7FrbtvyNa8fc3k0Q==",
 			"peer": true
 		},
 		"node_modules/web-streams-polyfill": {
@@ -10474,9 +10474,9 @@
 			}
 		},
 		"wdio-mediawiki": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-6.1.0.tgz",
-			"integrity": "sha512-fO5uA4AoVsr8eNl9VxkTQ+HF2Jhs2zGfasoofXgmQSvJvsZuehBJhF3DjWbFxPWZUfzal8iO1RjVT7cjYZoXnw==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/wdio-mediawiki/-/wdio-mediawiki-6.4.0.tgz",
+			"integrity": "sha512-aTkgHUF+rhLqnI2XiM+/fwgEitKU0cJcWXoIitrHxkt+07XYqvrgkUN1zcbETy5RGCGvf+7FrbtvyNa8fc3k0Q==",
 			"peer": true
 		},
 		"web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"test": "eslint ."
 	},
 	"peerDependencies": {
-		"wdio-mediawiki": "^6.0.0",
+		"wdio-mediawiki": "^6.4.0",
 		"webdriverio": "^9"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,10 @@
 		"test": "eslint ."
 	},
 	"peerDependencies": {
-		"mwbot": "^2.0.0",
-		"wdio-mediawiki": "^5.0.0",
+		"wdio-mediawiki": "^6.0.0",
 		"webdriverio": "^9"
 	},
 	"devDependencies": {
-		"eslint-config-wikimedia": "^0.31.0",
-		"request": "^2.88.2"
+		"eslint-config-wikimedia": "^0.31.0"
 	}
 }

--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -19,7 +19,7 @@ class WikibaseApi {
 	}
 
 	/**
-	 * @return {Promise<Object>} resolving with the API client
+	 * @return {Promise<Api>} resolving with the API client
 	 */
 	getApi() {
 		if ( !this.api ) {

--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -14,11 +14,7 @@ class WikibaseApi {
 	 * @return {Promise<Object>} resolving with the API client
 	 */
 	async initialize( cpPosIndex, mwUser, mwPwd ) {
-		this.api = await createApiClient();
-		await this.api.loginGetEditToken(
-			mwUser || browser.options.capabilities[ 'mw:user' ],
-			mwPwd || browser.options.capabilities[ 'mw:pwd' ]
-		);
+		this.api = await createApiClient( { username: mwUser, password: mwPwd } );
 		return this.api;
 	}
 

--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -15,7 +15,7 @@ class WikibaseApi {
 	 */
 	async initialize( cpPosIndex, mwUser, mwPwd ) {
 		this.client = await createApiClient();
-		await this.clieant.loginGetEditToken(
+		await this.client.loginGetEditToken(
 			mwUser || browser.options.capabilities[ 'mw:user' ],
 			mwPwd || browser.options.capabilities[ 'mw:pwd' ]
 		);

--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -14,12 +14,12 @@ class WikibaseApi {
 	 * @return {Promise<Object>} resolving with the API client
 	 */
 	async initialize( cpPosIndex, mwUser, mwPwd ) {
-		this.client = await createApiClient();
+		this.api = await createApiClient();
 		await this.client.loginGetEditToken(
 			mwUser || browser.options.capabilities[ 'mw:user' ],
 			mwPwd || browser.options.capabilities[ 'mw:pwd' ]
 		);
-		return this.client;
+		return this.api;
 	}
 
 	/**
@@ -87,7 +87,7 @@ class WikibaseApi {
 			action: 'wbeditentity',
 			new: 'property',
 			data: JSON.stringify( propertyData ),
-			token: api.api.getEditToken()
+			token: api.getEditToken()
 		} );
 
 		return response.entity.id;

--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -1,5 +1,4 @@
-import MWBot from 'mwbot';
-import request from 'request';
+import { createApiClient } from 'wdio-mediawiki/Api.js';
 
 class WikibaseApi {
 
@@ -12,41 +11,27 @@ class WikibaseApi {
 	 * (user name for logging into MediaWiki).
 	 * @param {string} [mwPwd] Override browser.options.capabilities[ 'mw:pwd' ]
 	 * (password for logging into MediaWiki).
-	 * @return {Promise<MWBot>} resolving with MWBot
+	 * @return {Promise<Object>} resolving with the API client
 	 */
 	async initialize( cpPosIndex, mwUser, mwPwd ) {
-		const jar = request.jar();
-		if ( cpPosIndex ) {
-			const cookie = request.cookie( `cpPosIndex=${ cpPosIndex }` );
-			jar.setCookie( cookie, browser.options.baseUrl );
-		}
-		const bot = new MWBot(
-			{
-				apiUrl: `${ browser.options.baseUrl }/api.php`
-			},
-			{
-				jar: jar
-			}
+		this.client = await createApiClient();
+		await this.clieant.loginGetEditToken(
+			mwUser || browser.options.capabilities[ 'mw:user' ],
+			mwPwd || browser.options.capabilities[ 'mw:pwd' ]
 		);
-		await bot.loginGetEditToken( {
-			username: mwUser || browser.options.capabilities[ 'mw:user' ],
-			password: mwPwd || browser.options.capabilities[ 'mw:pwd' ]
-		} );
-		this.bot = bot;
-
-		return bot;
+		return this.client;
 	}
 
 	/**
-	 * @return {Promise<MWBot>} resolving with MWBot
+	 * @return {Promise<Object>} resolving with the API client
 	 */
-	getBot() {
-		if ( !this.bot ) {
+	getApi() {
+		if ( !this.api ) {
 			console.trace( 'WARNING: WikibaseApi not initialized' );
 			return this.initialize();
 		}
 
-		return Promise.resolve( this.bot );
+		return Promise.resolve( this.api );
 	}
 
 	/**
@@ -73,13 +58,13 @@ class WikibaseApi {
 
 		Object.assign( itemData, { labels }, data );
 
-		const bot = await this.getBot();
+		const api = await this.getApi();
 
-		const response = await bot.request( {
+		const response = await api.request( {
 			action: 'wbeditentity',
 			new: 'item',
 			data: JSON.stringify( itemData ),
-			token: bot.editToken
+			token: api.getEditToken()
 		} );
 
 		return response.entity.id;
@@ -97,12 +82,12 @@ class WikibaseApi {
 
 		propertyData = Object.assign( {}, { datatype }, data );
 
-		const bot = await this.getBot();
-		const response = await bot.request( {
+		const api = await this.getApi();
+		const response = await api.request( {
 			action: 'wbeditentity',
 			new: 'property',
 			data: JSON.stringify( propertyData ),
-			token: bot.editToken
+			token: api.api.getEditToken()
 		} );
 
 		return response.entity.id;
@@ -113,11 +98,11 @@ class WikibaseApi {
 	 * @return {Promise<Object>} resolving with the requested entity
 	 */
 	async getEntity( id ) {
-		const bot = await this.getBot();
-		const response = await bot.request( {
+		const api = await this.getApi();
+		const response = await api.request( {
 			ids: id,
 			action: 'wbgetentities',
-			token: bot.editToken
+			token: api.getEditToken()
 		} );
 		return response.entities[ id ];
 	}
@@ -127,20 +112,20 @@ class WikibaseApi {
 	 * @return {Promise<Object>}
 	 */
 	async protectEntity( entityId ) {
-		const bot = await this.getBot();
+		const api = await this.getApi();
 
-		const getEntitiesResponse = await bot.request( {
+		const getEntitiesResponse = await api.request( {
 			action: 'wbgetentities',
 			format: 'json',
 			ids: entityId,
 			props: 'info'
 		} );
 		const entityTitle = getEntitiesResponse.entities[ entityId ].title;
-		return bot.request( {
+		return api.request( {
 			action: 'protect',
 			title: entityTitle,
 			protections: 'edit=sysop',
-			token: bot.editToken
+			token: api.getEditToken()
 		} );
 	}
 

--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -14,7 +14,11 @@ class WikibaseApi {
 	 * @return {Promise<Object>} resolving with the API client
 	 */
 	async initialize( cpPosIndex, mwUser, mwPwd ) {
-		this.api = await createApiClient( { username: mwUser, password: mwPwd } );
+		this.api = await createApiClient( {
+			username: mwUser,
+			password: mwPwd,
+			cookies: cpPosIndex ? { cpPosIndex } : undefined
+		} );
 		return this.api;
 	}
 
@@ -60,7 +64,7 @@ class WikibaseApi {
 			action: 'wbeditentity',
 			new: 'item',
 			data: JSON.stringify( itemData ),
-			token: api.getEditToken()
+			token: await api.getEditToken()
 		} );
 
 		return response.entity.id;
@@ -83,7 +87,7 @@ class WikibaseApi {
 			action: 'wbeditentity',
 			new: 'property',
 			data: JSON.stringify( propertyData ),
-			token: api.getEditToken()
+			token: await api.getEditToken()
 		} );
 
 		return response.entity.id;
@@ -98,7 +102,7 @@ class WikibaseApi {
 		const response = await api.request( {
 			ids: id,
 			action: 'wbgetentities',
-			token: api.getEditToken()
+			token: await api.getEditToken()
 		} );
 		return response.entities[ id ];
 	}
@@ -121,7 +125,7 @@ class WikibaseApi {
 			action: 'protect',
 			title: entityTitle,
 			protections: 'edit=sysop',
-			token: api.getEditToken()
+			token: await api.getEditToken()
 		} );
 	}
 

--- a/wikibase.api.js
+++ b/wikibase.api.js
@@ -15,7 +15,7 @@ class WikibaseApi {
 	 */
 	async initialize( cpPosIndex, mwUser, mwPwd ) {
 		this.api = await createApiClient();
-		await this.client.loginGetEditToken(
+		await this.api.loginGetEditToken(
 			mwUser || browser.options.capabilities[ 'mw:user' ],
 			mwPwd || browser.options.capabilities[ 'mw:pwd' ]
 		);


### PR DESCRIPTION
Hi! We are working on replacing mwbot [T415543](https://phabricator.wikimedia.org/T415543) since mwbot is using deprecated dependancies and some are flagged as security issues. In wdio-core we expose a simpler version of how to use the API with built in node fetch. We are also working on getting the wdio test to run faster with some changes in core so we also want to upgrade the wdio-mediawiki dependency because of that.

I've started with [a  change in Wikibase](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/1235623) and need to upgrade wdio-wikibase first. I made this PR but not sure how I can test it? 

Also I see the original code has the option of setting a cookie for _cpPosIndex_, but I can't see that its used anywhere? Do you know if its used and do you want to keep that functionality? If so let me know and [I'll add it](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1235793) to wdio-mediawiki and update the PR.

Please let me know if I can help out in anyway or change the PR or how I make this as easy as possible for you.