### PR TITLE
Bump version to 7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wdio-wikibase",
-	"version": "7.0.0",
+	"version": "7.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wdio-wikibase",
-			"version": "7.0.0",
+			"version": "7.1.0",
 			"license": "GPL-2.0+",
 			"devDependencies": {
 				"eslint-config-wikimedia": "^0.31.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wdio-wikibase",
-	"version": "7.0.0",
+	"version": "7.1.0",
 	"type": "module",
 	"description": "WebdriverIO plugin for testing a Wikibase repo.",
 	"homepage": "https://github.com/wmde/wdio-wikibase",


### PR DESCRIPTION
Bug: T416173

----

The only change since 7.0.0 is #97. I would say this isn’t a breaking change, because nothing changed about the way that wdio-wikibase itself is used, even though callers will have to adjust their wdio-mediawiki dependency and stop using mwbot. But at the same time, you could probably argue that the changed peer dependencies are breaking changes after all, and this should be version 8.0.0. WDYT?